### PR TITLE
Add functionality to plot a solution

### DIFF
--- a/loggibud/v1/plotting/plot_solution.py
+++ b/loggibud/v1/plotting/plot_solution.py
@@ -1,0 +1,74 @@
+"""Plots solution routes"""
+from typing import List, Optional
+
+import folium
+import numpy as np
+
+from loggibud.v1.types import CVRPSolution
+
+
+# All available map colors
+MAP_COLORS = (
+    "black",
+    "blue",
+    "darkred",
+    "purple",
+    "red",
+    "orange",
+    "green",
+    "pink",
+    "darkblue",
+    "beige",
+    "gray",
+    "lightgreen",
+    "lightblue",
+    "lightgray",
+    "cadetblue"
+)
+
+
+def plot_solution(
+    solution: CVRPSolution, route_indices_to_plot: Optional[List[int]] = None
+) -> None:
+    """Plot solutions routes in a map
+
+    Parameters
+    ----------
+    solution
+        A solution to any solver with the vehicles routes to plot
+
+    route_indices_to_plot
+        If specified, selects a smaller subset of routes to plot by their
+        indices. This can be useful to reduce the clutter in case of a
+        solution with too many vehicles
+    """
+    # Initialize map centered at the mean of the origins
+    origins_mean = np.mean(
+        [
+            (vehicle.origin.lat, vehicle.origin.lng)
+            for vehicle in solution.vehicles
+        ],
+        axis=0
+    )
+    m = folium.Map(
+        location=origins_mean, zoom_start=12, tiles="cartodbpositron",
+    )
+
+    num_vehicles = len(solution.vehicles)
+    route_indices_to_plot = route_indices_to_plot or range(num_vehicles)
+    vehicles_subset = [solution.vehicles[i] for i in route_indices_to_plot]
+
+    for i, vehicle in enumerate(vehicles_subset):
+        origin = (vehicle.origin.lat, vehicle.origin.lng)
+        folium.CircleMarker(origin, color="red", radius=3, weight=5).add_to(m)
+
+        vehicle_color = MAP_COLORS[i % len(MAP_COLORS)]
+        vehicle_coords = [(point.lat, point.lng) for point in vehicle.circuit]
+        folium.Polygon(
+            vehicle_coords,
+            popup=f"Vehicle {i + 1}",
+            color=vehicle_color,
+            weight=1,
+        ).add_to(m)
+
+    return m

--- a/loggibud/v1/plotting/plot_solution.py
+++ b/loggibud/v1/plotting/plot_solution.py
@@ -23,7 +23,7 @@ MAP_COLORS = (
     "lightgreen",
     "lightblue",
     "lightgray",
-    "cadetblue"
+    "cadetblue",
 )
 
 
@@ -48,10 +48,12 @@ def plot_solution(
             (vehicle.origin.lat, vehicle.origin.lng)
             for vehicle in solution.vehicles
         ],
-        axis=0
+        axis=0,
     )
     m = folium.Map(
-        location=origins_mean, zoom_start=12, tiles="cartodbpositron",
+        location=origins_mean,
+        zoom_start=12,
+        tiles="cartodbpositron",
     )
 
     num_vehicles = len(solution.vehicles)

--- a/loggibud/v1/plotting/plot_solution.py
+++ b/loggibud/v1/plotting/plot_solution.py
@@ -1,10 +1,13 @@
 """Plots solution routes"""
-from typing import List, Optional
+from typing import List, Iterable, Optional
 
 import folium
 import numpy as np
+import polyline
+import requests
 
-from loggibud.v1.types import CVRPSolution
+from loggibud.v1.types import CVRPSolution, Point
+from loggibud.v1.distances import OSRMConfig
 
 
 # All available map colors
@@ -27,10 +30,94 @@ MAP_COLORS = (
 )
 
 
-def plot_solution(
+def plot_cvrp_solution_routes(
+    solution: CVRPSolution,
+    route_indices_to_plot: Optional[List[int]] = None,
+    config: Optional[OSRMConfig] = None,
+) -> None:
+    """Plot solution routes in a map along the streets
+
+    Parameters
+    ----------
+    solution
+        A solution to any solver with the vehicles routes to plot
+
+    route_indices_to_plot
+        If specified, selects a smaller subset of routes to plot by their
+        indices. This can be useful to reduce the clutter in case of a
+        solution with too many vehicles
+
+    config
+        OSRM configuration
+    """
+    config = config or OSRMConfig()
+
+    # Initialize map centered at the mean of the origins
+    origins_mean = np.mean(
+        [
+            (vehicle.origin.lat, vehicle.origin.lng)
+            for vehicle in solution.vehicles
+        ],
+        axis=0,
+    )
+    m = folium.Map(
+        location=origins_mean,
+        zoom_start=12,
+        tiles="cartodbpositron",
+    )
+
+    num_vehicles = len(solution.vehicles)
+    route_indices_to_plot = route_indices_to_plot or range(num_vehicles)
+    vehicles_subset = [solution.vehicles[i] for i in route_indices_to_plot]
+
+    for i, vehicle in enumerate(vehicles_subset):
+        vehicle_color = MAP_COLORS[i % len(MAP_COLORS)]
+
+        # Plot origin
+        origin = (vehicle.origin.lat, vehicle.origin.lng)
+        folium.CircleMarker(origin, color="red", radius=3, weight=5).add_to(m)
+
+        # Plot street outlines
+        wiring = _route_wiring(vehicle.circuit, config)
+        folium.PolyLine(
+            wiring, color=vehicle_color, weight=1.0, popup=f"Vehicle {i}"
+        ).add_to(m)
+
+        # Plot the deliveries as regular points
+        for delivery in vehicle.deliveries:
+            folium.Circle(
+                location=(delivery.point.lat, delivery.point.lng),
+                radius=10,
+                fill=True,
+                color=vehicle_color,
+                popup=(
+                    f"Vehicle {i} ({delivery.point.lat}, {delivery.point.lng})"
+                ),
+            ).add_to(m)
+
+    return m
+
+
+def _route_wiring(points: Iterable[Point], config):
+    coords_uri = ";".join(f"{point.lng},{point.lat}" for point in points)
+
+    response = requests.get(
+        f"{config.host}/route/v1/driving/{coords_uri}?overview=simplified",
+        timeout=config.timeout_s,
+    )
+
+    data = response.json()
+    line = data["routes"][0]["geometry"]
+
+    return [(lat, lng) for lat, lng in polyline.decode(line)]
+
+
+def plot_cvrp_solution(
     solution: CVRPSolution, route_indices_to_plot: Optional[List[int]] = None
 ) -> None:
-    """Plot solutions routes in a map
+    """Plot solution deliveries in a map
+    This is a simplified version showing only the edges between each delivery.
+    It does not require an OSRM server configuration.
 
     Parameters
     ----------
@@ -68,7 +155,7 @@ def plot_solution(
         vehicle_coords = [(point.lat, point.lng) for point in vehicle.circuit]
         folium.Polygon(
             vehicle_coords,
-            popup=f"Vehicle {i + 1}",
+            popup=f"Vehicle {i}",
             color=vehicle_color,
             weight=1,
         ).add_to(m)

--- a/poetry.lock
+++ b/poetry.lock
@@ -520,6 +520,17 @@ importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 dev = ["pre-commit", "tox"]
 
 [[package]]
+name = "polyline"
+version = "1.4.0"
+description = "A Python implementation of Google's Encoded Polyline Algorithm Format."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = ">=1.8.0"
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.18"
 description = "Library for building powerful interactive command lines in Python"
@@ -839,7 +850,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1"
-content-hash = "9f1402ddaadebecc27aac9de8da19d638a3ffbee5b0d28705e09610df58b1bcf"
+content-hash = "d34ee0df7713bdbe6f2d15b98cd2b79d0b6870033c115369517fcfde2355c8a5"
 
 [metadata.files]
 absl-py = [
@@ -1149,6 +1160,10 @@ pickleshare = [
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
+polyline = [
+    {file = "polyline-1.4.0-py2.py3-none-any.whl", hash = "sha256:6559a0d5d37f4d14255744b3c6a648d5ff480d3d5c5f30186effc72a4142fd6c"},
+    {file = "polyline-1.4.0.tar.gz", hash = "sha256:7c7f89d09a09c7b6161bdbfb4fd304b186fc7a2060fa4f31cb3f61c646a5c074"},
 ]
 prompt-toolkit = [
     {file = "prompt_toolkit-3.0.18-py3-none-any.whl", hash = "sha256:bf00f22079f5fadc949f42ae8ff7f05702826a97059ffcc6281036ad40ac6f04"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ Shapely = "^1.7.1"
 pandas = "^1.2.3"
 geopandas = "^0.9.0"
 folium = "^0.12.1"
+polyline = "^1.4.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.3"


### PR DESCRIPTION
# Description

According to [this issue](https://github.com/loggi/loggibud/issues/19), it would be interesting to have a function to plot also the solution of a VPR solver. This PR creates a module for that.

There are two functions for plotting solutions.
The first shows the routes with street outlines, and thus it requires an OSRM server available.

![image](https://user-images.githubusercontent.com/10814987/120525184-3c665f80-c3ae-11eb-97e9-3abebec553b3.png)

The second is simpler and plots only the edges between each delivery:

![image](https://user-images.githubusercontent.com/10814987/120032434-8e833b80-bfd0-11eb-837d-35c3bac5eb12.png)

Of course, in large problems the plotting may become too messy. A suggestion to overcome this is to plot less routes. Thus, instead of attempting to select which routes would be the most appropriate, we leave the decision to the user. For that, there is an auxiliary variable `route_indices_to_plot` to help with that task.

![image](https://user-images.githubusercontent.com/10814987/120525129-2ce71680-c3ae-11eb-9ebf-b9ed726217c9.png)


![image](https://user-images.githubusercontent.com/10814987/120032701-f33e9600-bfd0-11eb-9297-01ed68e3729f.png)
