### PR TITLE
Add OSRM configuration to the solution evaluation

### DIFF
--- a/loggibud/v1/eval/task1.py
+++ b/loggibud/v1/eval/task1.py
@@ -1,11 +1,16 @@
 from pathlib import Path
 from argparse import ArgumentParser
+from typing import Optional
 
-from ..distances import calculate_route_distance_m
+from ..distances import calculate_route_distance_m, OSRMConfig
 from ..types import CVRPInstance, CVRPSolution
 
 
-def evaluate_solution(instance: CVRPInstance, solution: CVRPSolution):
+def evaluate_solution(
+    instance: CVRPInstance,
+    solution: CVRPSolution,
+    config: Optional[OSRMConfig] = None,
+) -> float:
 
     # Check if all demands are present.
     solution_demands = set(d for v in solution.vehicles for d in v.deliveries)
@@ -22,7 +27,8 @@ def evaluate_solution(instance: CVRPInstance, solution: CVRPSolution):
     assert len(origins) <= 1
 
     route_distances_m = [
-        calculate_route_distance_m(v.circuit) for v in solution.vehicles
+        calculate_route_distance_m(v.circuit, config=config)
+        for v in solution.vehicles
     ]
 
     # Convert to km.

--- a/tests/v1/test_task1_baselines.py
+++ b/tests/v1/test_task1_baselines.py
@@ -36,9 +36,12 @@ def mocked_lkh_osrm_distance_matrix():
 def mocked_osrm_route_distance():
     """Monkey-patch the OSRM route distance with the Great Circle"""
 
+    def _mocked_calculate_route_distance_m(points, config=None):
+        return calculate_route_distance_great_circle_m(points)
+
     with patch(
         "loggibud.v1.eval.task1.calculate_route_distance_m",
-        new=calculate_route_distance_great_circle_m,
+        new=_mocked_calculate_route_distance_m,
     ) as mock_osrm:
         yield mock_osrm
 

--- a/tests/v1/test_task2_baselines.py
+++ b/tests/v1/test_task2_baselines.py
@@ -42,9 +42,12 @@ def mocked_ortools_osrm_distance_matrix():
 def mocked_osrm_route_distance():
     """Monkey-patch the OSRM route distance with the Great Circle"""
 
+    def _mocked_calculate_route_distance_m(points, config=None):
+        return calculate_route_distance_great_circle_m(points)
+
     with patch(
         "loggibud.v1.eval.task1.calculate_route_distance_m",
-        new=calculate_route_distance_great_circle_m,
+        new=_mocked_calculate_route_distance_m,
     ) as mock_osrm:
         yield mock_osrm
 


### PR DESCRIPTION
# Description

Following [this issue's](https://github.com/loggi/loggibud/issues/20) quick discussion, this PR adds support for the OSRM configuration variable in the `evaluation_solution` function.