### PR TITLE
Fix IPEA broken links

### DIFF
--- a/loggibud/v1/instance_generation/download.sh
+++ b/loggibud/v1/instance_generation/download.sh
@@ -5,9 +5,9 @@ wget -P ./data_raw -nc ftp://ftp.ibge.gov.br/Censos/Censo_Demografico_2010/Resul
 
 # Download geographic data from IPEA
 # These files are indexed in "http://www.ipea.gov.br/geobr/metadata/metadata_gpkg.csv"
-wget -P ./data_raw -nc https://www.ipea.gov.br/geobr/data_gpkg/census_tract/2010/33.gpkg  # RJ
-wget -P ./data_raw -nc https://www.ipea.gov.br/geobr/data_gpkg/census_tract/2010/53.gpkg  # DF
-wget -P ./data_raw -nc https://www.ipea.gov.br/geobr/data_gpkg/census_tract/2010/15.gpkg  # PA
+wget -O ./data_raw/33.gpkg -nc 'https://www.ipea.gov.br/geobr/data_gpkg/census_tract/2010/33census_tract_2010.gpkg'  # RJ
+wget -O ./data_raw/53.gpkg -nc 'https://www.ipea.gov.br/geobr/data_gpkg/census_tract/2010/53census_tract_2010.gpkg'  # DF
+wget -O ./data_raw/15.gpkg -nc 'https://www.ipea.gov.br/geobr/data_gpkg/census_tract/2010/15census_tract_2010.gpkg'  # PA
 
 # Unzip.
 unzip -d ./data_raw -o ./data_raw/RJ_20171016.zip

--- a/loggibud/v1/instance_generation/download.sh
+++ b/loggibud/v1/instance_generation/download.sh
@@ -13,3 +13,12 @@ wget -O ./data_raw/15.gpkg -nc 'https://www.ipea.gov.br/geobr/data_gpkg/census_t
 unzip -d ./data_raw -o ./data_raw/RJ_20171016.zip
 unzip -d ./data_raw -o ./data_raw/DF_20171016.zip
 unzip -d ./data_raw -o ./data_raw/PA_20171016.zip
+
+# Ensure the standard of names of the directories generated 
+STATES=('DF' 'PA' 'RJ')
+for state in ${STATES[@]}; do
+  if [[ -e "data_raw/${state}" ]]; then
+    mv -v "$(find data_raw/${state}/Base*${state} -maxdepth 0)" "data_raw/${state}/Base informaçoes setores2010 universo ${state}"
+  fi
+done
+


### PR DESCRIPTION
refers to issue #24.

The links for download IPEA geographic data were replaced in download.sh script, keeping the structure of `data_raw` directory required in the generation pipeline.

refer to #1: Also was added a shell code to rename the subdirectories in `data_raw` keeping the pattern `"Base informaçoes ..."`

as result:
```
data_raw
├── DF
│   └── Base informaçoes setores2010 universo DF
│       ├── CSV
│       └── EXCEL
├── PA
│   └── Base informaçoes setores2010 universo PA
│       ├── CSV
│       └── EXCEL
└── RJ
    └── Base informaçoes setores2010 universo RJ
        ├── CSV
        └── EXCEL

12 directories
```